### PR TITLE
GFAccordion capabilities

### DIFF
--- a/lib/components/accordian/gf_accordian.dart
+++ b/lib/components/accordian/gf_accordian.dart
@@ -19,7 +19,7 @@ class GFAccordion extends StatefulWidget {
       this.titleborder = const Border(),
       this.contentBorder = const Border(),
       this.margin,
-      this.showAccordion})
+      this.showAccordion = false})
       : super(key: key);
 
   /// controls if the accordion should be collapsed or not making it possible to be controlled from outside

--- a/lib/components/accordian/gf_accordian.dart
+++ b/lib/components/accordian/gf_accordian.dart
@@ -18,8 +18,12 @@ class GFAccordion extends StatefulWidget {
       this.contentChild,
       this.titleborder = const Border(),
       this.contentBorder = const Border(),
-      this.margin})
+      this.margin,
+      this.showAccordion})
       : super(key: key);
+
+  /// controls if the accordion should be collapsed or not making it possible to be controlled from outside
+  final bool showAccordion;
 
   /// child of  type [Widget]is alternative to title key. title will get priority over titleChild
   final Widget titleChild;
@@ -75,10 +79,11 @@ class _GFAccordionState extends State<GFAccordion>
   AnimationController animationController;
   AnimationController controller;
   Animation<Offset> offset;
-  bool showAccordion = false;
+  bool showAccordion;
 
   @override
   void initState() {
+    showAccordion = widget.showAccordion;
     animationController = AnimationController(
       duration: const Duration(seconds: 2),
       vsync: this,

--- a/lib/components/accordian/gf_accordian.dart
+++ b/lib/components/accordian/gf_accordian.dart
@@ -176,9 +176,9 @@ class _GFAccordionState extends State<GFAccordion>
         default:
       }
       showAccordion = !showAccordion;
+      if (widget.onToggleCollapsed != null) {
+        widget.onToggleCollapsed(showAccordion);
+      }
     });
-    if (widget.onToggleCollapsed != null) {
-      widget.onToggleCollapsed(showAccordion);
-    }
   }
 }

--- a/lib/components/accordian/gf_accordian.dart
+++ b/lib/components/accordian/gf_accordian.dart
@@ -19,8 +19,11 @@ class GFAccordion extends StatefulWidget {
       this.titleborder = const Border(),
       this.contentBorder = const Border(),
       this.margin,
-      this.showAccordion = false})
+      this.showAccordion = false,
+      this.onToggleCollapsed})
       : super(key: key);
+
+  final Function(bool) onToggleCollapsed;
 
   /// controls if the accordion should be collapsed or not making it possible to be controlled from outside
   final bool showAccordion;
@@ -119,18 +122,7 @@ class _GFAccordionState extends State<GFAccordion>
           children: <Widget>[
             GestureDetector(
               onTap: () {
-                setState(() {
-                  switch (controller.status) {
-                    case AnimationStatus.completed:
-                      controller.forward(from: 0);
-                      break;
-                    case AnimationStatus.dismissed:
-                      controller.forward();
-                      break;
-                    default:
-                  }
-                  showAccordion = !showAccordion;
-                });
+                _toggleCollapsed();
               },
               child: Container(
                 decoration: BoxDecoration(
@@ -171,4 +163,22 @@ class _GFAccordionState extends State<GFAccordion>
           ],
         ),
       );
+
+  void _toggleCollapsed() {
+    setState(() {
+      switch (controller.status) {
+        case AnimationStatus.completed:
+          controller.forward(from: 0);
+          break;
+        case AnimationStatus.dismissed:
+          controller.forward();
+          break;
+        default:
+      }
+      showAccordion = !showAccordion;
+    });
+    if (widget.onToggleCollapsed != null) {
+      widget.onToggleCollapsed(showAccordion);
+    }
+  }
 }


### PR DESCRIPTION
Enables the possibility to control the showAccordion from outside, so that it becomes possible to build for example a menu that toggles topics collapsed in order to allow for one to keep only one topic open or other capabilities. Also adds a callback on the toggle event