### PR TITLE
fix page slide activateIndactor not refresh

### DIFF
--- a/lib/components/carousel/gf_carousel.dart
+++ b/lib/components/carousel/gf_carousel.dart
@@ -182,7 +182,7 @@ class _GFCarouselState extends State<GFCarousel> with TickerProviderStateMixin {
   }
 
   Timer getPlayTimer() => Timer.periodic(widget.autoPlayInterval, (_) {
-        if (widget.autoPlay) {
+        if (widget.autoPlay && widget.items.length > 1) {
           widget.pageController.nextPage(
               duration: widget.autoPlayAnimationDuration,
               curve: widget.autoPlayCurve);
@@ -221,7 +221,7 @@ class _GFCarouselState extends State<GFCarousel> with TickerProviderStateMixin {
   }
 
   void onPageSlide(int index) {
-    setState(() => index);
+    setState(() => currentSlide = index);
   }
 
   int currentSlide;


### PR DESCRIPTION
1. When sliding by hand, the activation indicator does not follow the slide.
2. It will jump next when items exceeds one.