### PR TITLE
[GFCarousel] fix null value issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+## 1.2.3 - 2020-10-21
+
+### Fixed
+* [GFCarousel] fix null value issue.
+
 ## 1.2.2 - 2020-10-02
 
 ### Fixed

--- a/lib/components/carousel/gf_carousel.dart
+++ b/lib/components/carousel/gf_carousel.dart
@@ -263,8 +263,7 @@ class _GFCarouselState extends State<GFCarousel> with TickerProviderStateMixin {
                 builder: (BuildContext context, child) {
                   // on the first render, the pageController.page is null,
                   // this is a dirty hack
-                  if (widget.pageController.position.minScrollExtent == null ||
-                      widget.pageController.position.maxScrollExtent == null) {
+                  if (!widget.pageController.position.hasContentDimensions) {
                     Future.delayed(const Duration(microseconds: 1), () {
                       setState(() {});
                     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: getwidget
 description: GetWidget is open source libraries that come with pre-build 1000+ UI components. It makes development faster & more enjoyable. You can customize the component as per your need.
-version: 1.2.2
+version: 1.2.3
 homepage: https://github.com/ionicfirebaseapp/getwidget
 
 environment:


### PR DESCRIPTION
Fix Issues on #185 & #196 using the new getter 

`position.hasContentDimensions`

 instead of 

`widget.pageController.position.minScrollExtent == null || widget.pageController.position.maxScrollExtent == null`