### PR TITLE
Fix issue accordion expand/collapse state was not change from outside

### DIFF
--- a/lib/components/accordion/gf_accordion.dart
+++ b/lib/components/accordion/gf_accordion.dart
@@ -114,6 +114,14 @@ class _GFAccordionState extends State<GFAccordion>
   }
 
   @override
+  void didUpdateWidget(GFAccordion oldWidget) {
+    if (oldWidget.showAccordion != widget.showAccordion) {
+      _toggleCollapsed(false);
+    }
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
   void dispose() {
     animationController.dispose();
     controller.dispose();
@@ -127,7 +135,9 @@ class _GFAccordionState extends State<GFAccordion>
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             InkWell(
-              onTap: _toggleCollapsed,
+              onTap: () {
+                _toggleCollapsed(true);
+              },
               child: Container(
                 decoration: BoxDecoration(
                   borderRadius: widget.titleBorderRadius,
@@ -170,7 +180,7 @@ class _GFAccordionState extends State<GFAccordion>
         ),
       );
 
-  void _toggleCollapsed() {
+  void _toggleCollapsed(bool changeShowAccordionState) {
     setState(() {
       switch (controller.status) {
         case AnimationStatus.completed:
@@ -181,7 +191,7 @@ class _GFAccordionState extends State<GFAccordion>
           break;
         default:
       }
-      showAccordion = !showAccordion;
+      showAccordion = changeShowAccordionState ? !widget.showAccordion : widget.showAccordion;
       if (widget.onToggleCollapsed != null) {
         widget.onToggleCollapsed!(showAccordion);
       }


### PR DESCRIPTION
Fix issue accordion was not expanded/collapsed if showAccordion was passed and change from parent widget

This issue can be reproduced with this snippet:
```dart
import 'package:flutter/material.dart';

import 'package:getwidget/getwidget.dart';

class AccordionScreen extends StatefulWidget {
  const AccordionScreen({Key? key}) : super(key: key);

  @override
  _AccordionScreenState createState() => _AccordionScreenState();
}

class _AccordionScreenState extends State<AccordionScreen> {
  bool showAccordion = false;
  String title = 'GF Accordion [Collapsed]';

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(),
      body: Column(
        children: [
          GFAccordion(
              showAccordion: showAccordion,
              title: title,
              content:
                  'GetFlutter is an open source library that comes with pre-build 1000+ UI components.'),
          ElevatedButton(
              onPressed: () {
                setState(() {
                  showAccordion = !showAccordion;
                  title = showAccordion
                      ? 'GF Accordion [Expanded]'
                      : 'GF Accordion [Collapsed]';
                });
              },
              child: Text(showAccordion ? 'Collapse' : 'Expand')),
        ],
      ),
    );
  }
}