### PR TITLE
[GFAppBar] clear button does not fire onSubmitted

### DIFF
--- a/lib/components/appbar/gf_appbar.dart
+++ b/lib/components/appbar/gf_appbar.dart
@@ -435,8 +435,10 @@ class _GFAppBarState extends State<GFAppBar> {
             type: GFButtonType.transparent,
             onPressed: () {
               widget.onSubmitted?.call("");
+              final controller = widget.searchController ?? _searchController;
               setState(() {
                 showSearchBar = !showSearchBar;
+                controller.text = "";
               });
             },
           ),

--- a/lib/components/appbar/gf_appbar.dart
+++ b/lib/components/appbar/gf_appbar.dart
@@ -1,4 +1,4 @@
-isublmport 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -434,7 +434,7 @@ class _GFAppBarState extends State<GFAppBar> {
             ),
             type: GFButtonType.transparent,
             onPressed: () {
-              widget.onSubmitted?.call(null);
+              widget.onSubmitted?.call("");
               setState(() {
                 showSearchBar = !showSearchBar;
               });

--- a/lib/components/appbar/gf_appbar.dart
+++ b/lib/components/appbar/gf_appbar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+isublmport 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -434,6 +434,7 @@ class _GFAppBarState extends State<GFAppBar> {
             ),
             type: GFButtonType.transparent,
             onPressed: () {
+              widget.onSubmitted?.call(null);
               setState(() {
                 showSearchBar = !showSearchBar;
               });


### PR DESCRIPTION
On GFAppBar close button must trigger onSubmitted with empty string event since the user already have finish to work with search TextEditingController.

The onChanged event must be sent when the user is still working with TextEditingController.

#149 