### PR TITLE
Update gf_card.dart for flutter 3.27

### DIFF
--- a/lib/components/card/gf_card.dart
+++ b/lib/components/card/gf_card.dart
@@ -115,7 +115,7 @@ class GFCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final CardTheme cardTheme = CardTheme.of(context);
+    final CardThemeData cardTheme = CardTheme.of(context);
 
     final Widget cardChild = Padding(
       padding: padding,


### PR DESCRIPTION
Change type from CardTheme to CardThemeData in response to breaking change in flutter 3.27.
Addresses issue #357 