### PR TITLE
fix: remove direct reference to CardThemeData for Flutter version compatibility

### DIFF
--- a/lib/components/card/gf_card.dart
+++ b/lib/components/card/gf_card.dart
@@ -115,7 +115,7 @@ class GFCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final CardThemeData cardTheme = CardTheme.of(context);
+    final cardTheme = CardTheme.of(context);
 
     final Widget cardChild = Padding(
       padding: padding,


### PR DESCRIPTION
Direct usage of `CardThemeData` causes build failures on older Flutter SDKs  
where this type does not exist. Replaced it with untyped (inferred or `dynamic`)  
references to ensure compatibility across versions.

Access to `CardTheme` properties (`color`, `elevation`, `clipBehavior`, `margin`)  
is now handled dynamically, maintaining functionality without breaking builds  
on earlier versions of Flutter.

## Details

- Removed direct reference to `CardThemeData`.
- Used type inference to avoid compile-time dependency on version-specific types.
